### PR TITLE
add fields to MarketSummary data

### DIFF
--- a/marketSummary.go
+++ b/marketSummary.go
@@ -1,11 +1,15 @@
 package bittrex
 
 type MarketSummary struct {
-	MarketName string  `json:"MarketName"`
-	High       float64 `json:"High"`
-	Low        float64 `json:"Low"`
-	Volume     float64 `json:"Volume"`
-	Last       float64 `json:"Last"`
-	BaseVolume float64 `json:"BaseVolume"`
-	TimeStamp  string  `json:"TimeStamp"`
+	MarketName     string  `json:"MarketName"`
+	High           float64 `json:"High"`
+	Low            float64 `json:"Low"`
+	Ask            float64 `json:"Ask"`
+	Bid            float64 `json:"Bid"`
+	OpenBuyOrders  int     `json:"OpenBuyOrders"`
+	OpenSellOrders int     `json:"OpenSellOrders"`
+	Volume         float64 `json:"Volume"`
+	Last           float64 `json:"Last"`
+	BaseVolume     float64 `json:"BaseVolume"`
+	TimeStamp      string  `json:"TimeStamp"`
 }


### PR DESCRIPTION
I had a need for buys/sells data in the market summary data, so I added them. 
