### PR TITLE
Add GetTicks (prev GetHisCandles) method

### DIFF
--- a/candle.go
+++ b/candle.go
@@ -1,12 +1,13 @@
 package bittrex
 
 type Candle struct {
-	TimeStamp CandleTime `json:"T"`
-	Open      float64    `json:"O"`
-	Close     float64    `json:"C"`
-	High      float64    `json:"H"`
-	Low       float64    `json:"L"`
-	Volume    float64    `json:"V"`
+	TimeStamp  CandleTime `json:"T"`
+	Open       float64    `json:"O"`
+	Close      float64    `json:"C"`
+	High       float64    `json:"H"`
+	Low        float64    `json:"L"`
+	Volume     float64    `json:"V"`
+	BaseVolume float64    `json:"BV"`
 }
 
 type NewCandles struct {

--- a/candleTime.go
+++ b/candleTime.go
@@ -1,14 +1,16 @@
 package bittrex
 
 import (
-	"strconv"
+	"fmt"
 	"time"
 )
 
 var CANDLE_INTERVALS = map[string]bool{
-	"tenmin": true,
-	"hour":   true,
-	"day":    true,
+	"oneMin":    true,
+	"fiveMin":   true,
+	"thirtyMin": true,
+	"hour":      true,
+	"day":       true,
 }
 
 type CandleTime struct {
@@ -16,13 +18,14 @@ type CandleTime struct {
 }
 
 func (t *CandleTime) UnmarshalJSON(b []byte) error {
-	result, err := strconv.ParseInt(string(b)[8:18], 10, 64)
-
-	if err != nil {
-		return err
+	if len(b) < 2 {
+		return fmt.Errorf("could not parse time %s", string(b))
 	}
-
-	t.Time = time.Unix(result, 0)
-
+	// trim enclosing ""
+	result, err := time.Parse("2006-01-02T15:04:05", string(b[1:len(b)-1]))
+	if err != nil {
+		return fmt.Errorf("could not parse time: %v", err)
+	}
+	t.Time = result
 	return nil
 }


### PR DESCRIPTION
@toorop, @everyone
Since bittrex updated their API, https://bittrex.com/Market/Pub_GetNewTickData and https://bittrex.com/Market/Pub_GetTickData are not valid endpoints now. They were cleaned in https://github.com/toorop/go-bittrex/pull/21. But still there is a way to get ticks history from their API.

[/GetTicks](https://bittrex.com/Api/v2.0/pub/market/GetTicks?marketName=BTC-WAVES&tickInterval=day&_=1499114009) endpoint returns all the data we want.

