### PR TITLE
Add possibilty to use custom http client settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _testmain.go
 
 *.exe
 *.test
+go-bittrex.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-    "time"
+	"time"
 	"github.com/toorop/go-bittrex"
 )
 
@@ -54,15 +54,15 @@ const (
 
 func main() {
 	httpClient := &http.Client{
-        Timeout: time.Second * 10,
-    }
+		Timeout: time.Second * 10,
+	}
 
-    // Bittrex client
-    bc := bittrex.NewWithCustomHttpClient(conf.Bittrex.ApiKey, conf.Bittrex.ApiSecret, httpClient)
+	// Bittrex client
+	bc := bittrex.NewWithCustomHttpClient(conf.Bittrex.ApiKey, conf.Bittrex.ApiSecret, httpClient)
 
 	// Get markets
-    markets, err := bittrex.GetMarkets()
-    fmt.Println(err, markets)
+	markets, err := bittrex.GetMarkets()
+	fmt.Println(err, markets)
 }
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This version implement V1.1 Bittrex API and the new HMAC authentification.
 	import "github.com/toorop/go-bittrex"
 	
 ## Usage
+
+In order to use the client with go's default http client settings you can do:
+
 ~~~ go
 package main
 
@@ -30,7 +33,38 @@ func main() {
 	markets, err := bittrex.GetMarkets()
 	fmt.Println(err, markets)
 }
-~~~	
+~~~
+
+In order to use custom settings for the http client do:
+
+~~~ go
+package main
+
+import (
+	"fmt"
+	"net/http"
+    "time"
+	"github.com/toorop/go-bittrex"
+)
+
+const (
+	API_KEY    = "YOUR_API_KEY"
+	API_SECRET = "YOUR_API_SECRET"
+)
+
+func main() {
+	httpClient := &http.Client{
+        Timeout: time.Second * 10,
+    }
+
+    // Bittrex client
+    bc := bittrex.NewWithCustomHttpClient(conf.Bittrex.ApiKey, conf.Bittrex.ApiSecret, httpClient)
+
+	// Get markets
+    markets, err := bittrex.GetMarkets()
+    fmt.Println(err, markets)
+}
+~~~
 
 See ["Examples" folder for more... examples](https://github.com/toorop/go-bittrex/blob/master/examples/bittrex.go)
 

--- a/bittrex.go
+++ b/bittrex.go
@@ -23,7 +23,7 @@ func New(apiKey, apiSecret string) *Bittrex {
 	return &Bittrex{client}
 }
 
-// New returns an instanciated bittrex struct with custom http client
+// NewWithCustomHttpClient returns an instanciated bittrex struct with custom http client
 func NewWithCustomHttpClient(apiKey, apiSecret string, httpClient *http.Client) *Bittrex {
 	client := NewClientWithCustomHttpConfig(apiKey, apiSecret, httpClient)
 	return &Bittrex{client}

--- a/bittrex.go
+++ b/bittrex.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -16,9 +17,15 @@ const (
 	DEFAULT_HTTPCLIENT_TIMEOUT = 30                         // HTTP client timeout
 )
 
-// New return a instanciate bittrex struct
+// New returns an instanciated bittrex struct
 func New(apiKey, apiSecret string) *Bittrex {
 	client := NewClient(apiKey, apiSecret)
+	return &Bittrex{client}
+}
+
+// New returns an instanciated bittrex struct with custom http client
+func NewWithCustomHttpClient(apiKey, apiSecret string, httpClient *http.Client) *Bittrex {
+	client := NewClientWithCustomHttpConfig(apiKey, apiSecret, httpClient)
 	return &Bittrex{client}
 }
 

--- a/client.go
+++ b/client.go
@@ -23,6 +23,11 @@ func NewClient(apiKey, apiSecret string) (c *client) {
 	return &client{apiKey, apiSecret, &http.Client{}}
 }
 
+// NewClientWithCustomHttpConfig returns a new Bittrex HTTP client using the predefined http client
+func NewClientWithCustomHttpConfig(apiKey, apiSecret string, httpClient *http.Client) (c *client) {
+	return &client{apiKey, apiSecret, httpClient}
+}
+
 // doTimeoutRequest do a HTTP request with timeout
 func (c *client) doTimeoutRequest(timer *time.Timer, req *http.Request) (*http.Response, error) {
 	// Do the request in the background so we can check the timeout


### PR DESCRIPTION
A http timeout is handled in the code very well but unfortunately there is no possibilty to use any other setting than the default one which effectively means no timeout is set. This PR aims to add the possibilty to use custom http client settings without breaking backward compatibility.