### PR TITLE
httpTimeout field in client struct (used in connectTimer), new initialization functions

### DIFF
--- a/bittrex.go
+++ b/bittrex.go
@@ -9,23 +9,29 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
-	API_BASE                   = "https://bittrex.com/api/" // Bittrex API endpoint
-	API_VERSION                = "v1.1"                     // Bittrex API version
-	DEFAULT_HTTPCLIENT_TIMEOUT = 30                         // HTTP client timeout
+	API_BASE    = "https://bittrex.com/api/" // Bittrex API endpoint
+	API_VERSION = "v1.1"                     // Bittrex API version
 )
 
-// New returns an instanciated bittrex struct
+// New returns an instantiated bittrex struct
 func New(apiKey, apiSecret string) *Bittrex {
 	client := NewClient(apiKey, apiSecret)
 	return &Bittrex{client}
 }
 
-// NewWithCustomHttpClient returns an instanciated bittrex struct with custom http client
+// NewWithCustomHttpClient returns an instantiated bittrex struct with custom http client
 func NewWithCustomHttpClient(apiKey, apiSecret string, httpClient *http.Client) *Bittrex {
 	client := NewClientWithCustomHttpConfig(apiKey, apiSecret, httpClient)
+	return &Bittrex{client}
+}
+
+// NewWithCustomTimeout returns an instantiated bittrex struct with custom timeout
+func NewWithCustomTimeout(apiKey, apiSecret string, timeout time.Duration) *Bittrex {
+	client := NewClientWithCustomTimeout(apiKey, apiSecret, timeout)
 	return &Bittrex{client}
 }
 

--- a/client.go
+++ b/client.go
@@ -13,19 +13,21 @@ import (
 )
 
 type client struct {
-	apiKey     string
-	apiSecret  string
-	httpClient *http.Client
+	apiKey      string
+	apiSecret   string
+	httpClient  *http.Client
+	httpTimeout time.Duration
 }
 
 // NewClient return a new Bittrex HTTP client
 func NewClient(apiKey, apiSecret string) (c *client) {
-	return &client{apiKey, apiSecret, &http.Client{}}
+	return &client{apiKey, apiSecret, &http.Client{}, 30 * time.Second}
 }
 
 // NewClientWithCustomHttpConfig returns a new Bittrex HTTP client using the predefined http client
 func NewClientWithCustomHttpConfig(apiKey, apiSecret string, httpClient *http.Client) (c *client) {
-	return &client{apiKey, apiSecret, httpClient}
+	timeout := httpClient.Timeout
+	return &client{apiKey, apiSecret, httpClient, timeout}
 }
 
 // doTimeoutRequest do a HTTP request with timeout
@@ -51,7 +53,7 @@ func (c *client) doTimeoutRequest(timer *time.Timer, req *http.Request) (*http.R
 
 // do prepare and process HTTP request to Bittrex API
 func (c *client) do(method string, ressource string, payload string, authNeeded bool) (response []byte, err error) {
-	connectTimer := time.NewTimer(DEFAULT_HTTPCLIENT_TIMEOUT * time.Second)
+	connectTimer := time.NewTimer(c.httpTimeout)
 
 	var rawurl string
 	if strings.HasPrefix(ressource, "http") {

--- a/client.go
+++ b/client.go
@@ -27,7 +27,15 @@ func NewClient(apiKey, apiSecret string) (c *client) {
 // NewClientWithCustomHttpConfig returns a new Bittrex HTTP client using the predefined http client
 func NewClientWithCustomHttpConfig(apiKey, apiSecret string, httpClient *http.Client) (c *client) {
 	timeout := httpClient.Timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
 	return &client{apiKey, apiSecret, httpClient, timeout}
+}
+
+// NewClient returns a new Bittrex HTTP client with custom timeout
+func NewClientWithCustomTimeout(apiKey, apiSecret string, timeout time.Duration) (c *client) {
+	return &client{apiKey, apiSecret, &http.Client{}, timeout}
 }
 
 // doTimeoutRequest do a HTTP request with timeout


### PR DESCRIPTION
HTTP timeout variable moved from bittrex.go to client struct in client.go file to achieve easier configurability.
Added new initialization functions to create new client with specified timeout value.
When passing custom HttpClient, its Timeout value is also set to httpTimeout field in client struct.
HttpTimeout value in client struct is used in connectTimer.