### PR TITLE
ws: add streaming updates support.

### DIFF
--- a/bittrex.go
+++ b/bittrex.go
@@ -14,6 +14,8 @@ import (
 const (
 	API_BASE                   = "https://bittrex.com/api/" // Bittrex API endpoint
 	API_VERSION                = "v1.1"                     // Bittrex API version
+	WS_BASE                    = "socket.bittrex.com"       // Bittrex WS API endpoint
+	WS_HUB                     = "CoreHub"                  // SignalR main hub
 	DEFAULT_HTTPCLIENT_TIMEOUT = 30                         // HTTP client timeout
 )
 

--- a/orderBook.go
+++ b/orderBook.go
@@ -1,11 +1,13 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type OrderBook struct {
 	Buy  []Orderb `json:"buy"`
 	Sell []Orderb `json:"sell"`
 }
 
 type Orderb struct {
-	Quantity float64 `json:"Quantity"`
-	Rate     float64 `json:"Rate"`
+	Quantity decimal.Decimal `json:"Quantity"`
+	Rate     decimal.Decimal `json:"Rate"`
 }

--- a/ws.go
+++ b/ws.go
@@ -111,6 +111,9 @@ func (b *Bittrex) SubscribeExchangeUpdate(market string, dataCh chan<- ExchangeS
 	}
 	st.Initial = true
 	sendStateAsync(dataCh, st)
-	<-stop
+	select {
+	case <-stop:
+	case <-client.DisconnectedChannel:
+	}
 	return nil
 }

--- a/ws.go
+++ b/ws.go
@@ -44,7 +44,7 @@ func doAsyncTimeout(f func() error, tmFunc func(error), timeout time.Duration) e
 	case err := <-errs:
 		return err
 	case <-time.After(timeout):
-		return errors.New("callhub timeout")
+		return errors.New("operation timeout")
 	}
 }
 

--- a/ws.go
+++ b/ws.go
@@ -2,7 +2,6 @@ package bittrex
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/thebotguys/signalr"
 )
@@ -42,7 +41,6 @@ func (b *Bittrex) SubscribeExchangeUpdate(market string, dataCh chan<- ExchangeS
 		for _, msg := range messages {
 			var st ExchangeState
 			if err := json.Unmarshal(msg, &st); err != nil {
-				fmt.Println(err)
 				continue
 			}
 			if st.MarketName != market {

--- a/ws.go
+++ b/ws.go
@@ -28,58 +28,89 @@ type ExchangeState struct {
 	Initial    bool
 }
 
-func (b *Bittrex) SubscribeExchangeUpdate(market string, dataCh chan<- ExchangeState, stop <-chan bool) error {
-	client := signalr.NewWebsocketClient()
-	sendUpdate := func(st ExchangeState) {
+func doAsyncTimeout(f func() error, tmFunc func(error), timeout time.Duration) error {
+	errs := make(chan error)
+	go func() {
+		err := f()
 		select {
-		case dataCh <- st:
+		case errs <- err:
 		default:
+			if tmFunc != nil {
+				tmFunc(err)
+			}
 		}
+	}()
+	select {
+	case err := <-errs:
+		return err
+	case <-time.After(timeout):
+		return errors.New("callhub timeout")
 	}
+}
+
+func sendStateAsync(dataCh chan<- ExchangeState, st ExchangeState) {
+	select {
+	case dataCh <- st:
+	default:
+	}
+}
+
+func subForMarket(client *signalr.Client, market string) (json.RawMessage, error) {
+	_, err := client.CallHub(WS_HUB, "SubscribeToExchangeDeltas", market)
+	if err != nil {
+		return json.RawMessage{}, err
+	}
+	return client.CallHub(WS_HUB, "QueryExchangeState", market)
+}
+
+func parseStates(messages []json.RawMessage, dataCh chan<- ExchangeState, market string) {
+	for _, msg := range messages {
+		var st ExchangeState
+		if err := json.Unmarshal(msg, &st); err != nil {
+			continue
+		}
+		if st.MarketName != market {
+			continue
+		}
+		sendStateAsync(dataCh, st)
+	}
+}
+
+func (b *Bittrex) SubscribeExchangeUpdate(market string, dataCh chan<- ExchangeState, stop <-chan bool) error {
+	const timeout = 5 * time.Second
+	client := signalr.NewWebsocketClient()
 	client.OnClientMethod = func(hub string, method string, messages []json.RawMessage) {
 		if hub != "CoreHub" || method != "updateExchangeState" {
 			return
 		}
-		for _, msg := range messages {
-			var st ExchangeState
-			if err := json.Unmarshal(msg, &st); err != nil {
-				continue
-			}
-			if st.MarketName != market {
-				continue
-			}
-			sendUpdate(st)
-		}
+		parseStates(messages, dataCh, market)
 	}
-	if err := client.Connect("https", WS_BASE, []string{WS_HUB}); err != nil {
+	err := doAsyncTimeout(func() error {
+		return client.Connect("https", WS_BASE, []string{WS_HUB})
+	}, func(err error) {
+		if err == nil {
+			client.Close()
+		}
+	}, timeout)
+	if err != nil {
 		return err
 	}
 	defer client.Close()
-	errCh := make(chan error, 1)
 	var msg json.RawMessage
-	go func() {
-		_, err := client.CallHub(WS_HUB, "SubscribeToExchangeDeltas", market)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		msg, err = client.CallHub(WS_HUB, "QueryExchangeState", market)
-		errCh <- err
-	}()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return err
-		}
-	case <-time.After(time.Second * 5):
-		return errors.New("callhub timeout")
+	err = doAsyncTimeout(func() error {
+		var err error
+		msg, err = subForMarket(client, market)
+		return err
+	}, nil, timeout)
+	if err != nil {
+		return err
 	}
 	var st ExchangeState
-	if err := json.Unmarshal(msg, &st); err != nil {
+	if err = json.Unmarshal(msg, &st); err != nil {
 		return err
 	}
 	st.Initial = true
-	sendUpdate(st)
+	sendStateAsync(dataCh, st)
 	<-stop
 	return nil
 }

--- a/ws.go
+++ b/ws.go
@@ -19,6 +19,7 @@ type Fill struct {
 	Timestamp jTime
 }
 
+// ExchangeState contains fills and order book updates for a market.
 type ExchangeState struct {
 	MarketName string
 	Nounce     int
@@ -28,6 +29,9 @@ type ExchangeState struct {
 	Initial    bool
 }
 
+// doAsyncTimeout runs f in a different goroutine
+//	if f returns before timeout elapses, doAsyncTimeout returns the result of f().
+//	otherwise it returns "operation timeout" error, and calls tmFunc after f returns.
 func doAsyncTimeout(f func() error, tmFunc func(error), timeout time.Duration) error {
 	errs := make(chan error)
 	go func() {
@@ -76,6 +80,9 @@ func parseStates(messages []json.RawMessage, dataCh chan<- ExchangeState, market
 	}
 }
 
+// SubscribeExchangeUpdate subscribes for updates of the market.
+// Updates will be sent to dataCh.
+// To stop subscription, send to, or close 'stop'.
 func (b *Bittrex) SubscribeExchangeUpdate(market string, dataCh chan<- ExchangeState, stop <-chan bool) error {
 	const timeout = 5 * time.Second
 	client := signalr.NewWebsocketClient()

--- a/ws.go
+++ b/ws.go
@@ -1,0 +1,77 @@
+package bittrex
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/thebotguys/signalr"
+)
+
+type orderUpdate struct {
+	Orderb
+	Type int
+}
+
+type fill struct {
+	Orderb
+	OrderType string
+	Timestamp jTime
+}
+
+type exchangeState struct {
+	MarketName string
+	Nounce     int
+	Buys       []orderUpdate
+	Sells      []orderUpdate
+	Fills      []fill
+}
+
+func (b *Bittrex) SubscribeOrderBook(market string, stop <-chan bool) error {
+	var lastNonce int
+	var states []exchangeState
+	client := signalr.NewWebsocketClient()
+	client.OnClientMethod = func(hub string, method string, messages []json.RawMessage) {
+		println(hub, method)
+		if method != "updateExchangeState" {
+			return
+		}
+		isFirst := lastNonce == 0 && len(states) == 0
+		for _, msg := range messages {
+			var st exchangeState
+			if err := json.Unmarshal(msg, &st); err != nil {
+				fmt.Println(err)
+				continue
+			}
+			if st.MarketName != market {
+				continue
+			}
+			if lastNonce == 0 {
+				states = append(states, st)
+				continue
+			}
+			fmt.Println(st)
+		}
+		if isFirst && len(states) > 0 {
+			// we've got first exchange update. we can now request the entire state.
+		}
+	}
+	if err := client.Connect("https", WS_BASE, []string{WS_HUB}); err != nil {
+		return err
+	}
+	defer client.Close()
+	_, err := client.CallHub(WS_HUB, "SubscribeToExchangeDeltas", market)
+	if err != nil {
+		return err
+	}
+	msg, err := client.CallHub(WS_HUB, "QueryExchangeState", market)
+	if err != nil {
+		return err
+	}
+	var st exchangeState
+	if err := json.Unmarshal(msg, &st); err != nil {
+		fmt.Println(err)
+		return err
+	}
+	<-stop
+	return nil
+}

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,12 +1,40 @@
 package bittrex
 
 import (
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestBittrexSubscribeOrderBook(t *testing.T) {
 	bt := New("", "")
-	if err := bt.SubscribeOrderBook("BTC-LTC", nil); err != nil {
-		t.Error(err)
+	ch := make(chan ExchangeState, 16)
+	errCh := make(chan error)
+	go func() {
+		var haveInit bool
+		var msgNum int
+		for st := range ch {
+			haveInit = haveInit || st.Initial
+			msgNum++
+			if msgNum >= 3 {
+				break
+			}
+		}
+		if haveInit {
+			errCh <- nil
+		} else {
+			errCh <- errors.New("no initial message")
+		}
+	}()
+	go func() {
+		errCh <- bt.SubscribeExchangeUpdate("USDT-BTC", ch, nil)
+	}()
+	select {
+	case <-time.After(time.Second * 5):
+		t.Error("timeout")
+	case err := <-errCh:
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,0 +1,12 @@
+package bittrex
+
+import (
+	"testing"
+)
+
+func TestBittrexSubscribeOrderBook(t *testing.T) {
+	bt := New("", "")
+	if err := bt.SubscribeOrderBook("BTC-LTC", nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/ws_test.go
+++ b/ws_test.go
@@ -30,7 +30,7 @@ func TestBittrexSubscribeOrderBook(t *testing.T) {
 		errCh <- bt.SubscribeExchangeUpdate("USDT-BTC", ch, nil)
 	}()
 	select {
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 6):
 		t.Error("timeout")
 	case err := <-errCh:
 		if err != nil {


### PR DESCRIPTION
This PR adds streaming updates support via SignalR.
It contains one breaking change: fields in `Orderb` now have `decimal.Decimal` type, as mentioned in #23 .