### PR TITLE
Change json Tag for Trade struct from OrderUuid to Id

### DIFF
--- a/trade.go
+++ b/trade.go
@@ -2,7 +2,7 @@ package bittrex
 
 // Used in getmarkethistory
 type Trade struct {
-	OrderUuid string  `json:"OrderUuid"`
+	OrderUuid int64   `json:"Id"`
 	Timestamp jTime   `json:"TimeStamp"`
 	Quantity  float64 `json:"Quantity"`
 	Price     float64 `json:"Price"`


### PR DESCRIPTION
The Trade type should have ID uint64 \`json:"Id"\` instead of the OrderUuid field. Maybe the API changed recently.