### PR TITLE
README: add godoc reference in heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-go-bittrex
+go-bittrex [![GoDoc](https://godoc.org/github.com/toorop/go-bittrex?status.svg)](https://godoc.org/github.com/toorop/go-bittrex)
 ==========
 
 go-bittrex is an implementation of the Bittrex API (public and private) in Golang.


### PR DESCRIPTION
Provide the GoDoc reference in the README's heading.

Exhibit:

### Before
<img width="731" alt="screen shot 2017-10-08 at 4 29 28 pm" src="https://user-images.githubusercontent.com/4898263/31321607-e33f1eb6-ac45-11e7-8dd1-d0385d09e59e.png">


### After
<img width="748" alt="screen shot 2017-10-08 at 4 28 38 pm" src="https://user-images.githubusercontent.com/4898263/31321601-d37e4326-ac45-11e7-8dc5-a71aa851eb28.png">
