### PR TITLE
Fix uncertainity with small amounts

### DIFF
--- a/Distribution.go
+++ b/Distribution.go
@@ -1,11 +1,13 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Distribution struct {
-	Distribution   []BalanceD `json:"Distribution"`
-	Balances       float64    `json:"Balances"`
-	AverageBalance float64    `json:"AverageBalance"`
+	Distribution   []BalanceD      `json:"Distribution"`
+	Balances       decimal.Decimal `json:"Balances"`
+	AverageBalance decimal.Decimal `json:"AverageBalance"`
 }
 
 type BalanceD struct {
-	BalanceD float64 `json:"Balance"`
+	BalanceD decimal.Decimal `json:"Balance"`
 }

--- a/balance.go
+++ b/balance.go
@@ -1,11 +1,13 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Balance struct {
-	Currency      string  `json:"Currency"`
-	Balance       float64 `json:"Balance"`
-	Available     float64 `json:"Available"`
-	Pending       float64 `json:"Pending"`
-	CryptoAddress string  `json:"CryptoAddress"`
-	Requested     bool    `json:"Requested"`
-	Uuid          string  `json:"Uuid"`
+	Currency      string          `json:"Currency"`
+	Balance       decimal.Decimal `json:"Balance"`
+	Available     decimal.Decimal `json:"Available"`
+	Pending       decimal.Decimal `json:"Pending"`
+	CryptoAddress string          `json:"CryptoAddress"`
+	Requested     bool            `json:"Requested"`
+	Uuid          string          `json:"Uuid"`
 }

--- a/candle.go
+++ b/candle.go
@@ -1,13 +1,15 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Candle struct {
-	TimeStamp  CandleTime `json:"T"`
-	Open       float64    `json:"O"`
-	Close      float64    `json:"C"`
-	High       float64    `json:"H"`
-	Low        float64    `json:"L"`
-	Volume     float64    `json:"V"`
-	BaseVolume float64    `json:"BV"`
+	TimeStamp  CandleTime      `json:"T"`
+	Open       decimal.Decimal `json:"O"`
+	Close      decimal.Decimal `json:"C"`
+	High       decimal.Decimal `json:"H"`
+	Low        decimal.Decimal `json:"L"`
+	Volume     decimal.Decimal `json:"V"`
+	BaseVolume decimal.Decimal `json:"BV"`
 }
 
 type NewCandles struct {

--- a/currency.go
+++ b/currency.go
@@ -1,12 +1,14 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Currency struct {
-	Currency        string  `json:"Currency"`
-	CurrencyLong    string  `json:"CurrencyLong"`
-	MinConfirmation int     `json:"MinConfirmation"`
-	TxFee           float64 `json:"TxFee"`
-	IsActive        bool    `json:"IsActive"`
-	CoinType        string  `json:"CoinType"`
-	BaseAddress     string  `json:"BaseAddress"`
-	Notice          string  `json:"Notice"`
+	Currency        string          `json:"Currency"`
+	CurrencyLong    string          `json:"CurrencyLong"`
+	MinConfirmation int             `json:"MinConfirmation"`
+	TxFee           decimal.Decimal `json:"TxFee"`
+	IsActive        bool            `json:"IsActive"`
+	CoinType        string          `json:"CoinType"`
+	BaseAddress     string          `json:"BaseAddress"`
+	Notice          string          `json:"Notice"`
 }

--- a/deposit.go
+++ b/deposit.go
@@ -1,11 +1,13 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Deposit struct {
-	Id            int64   `json:"Id"`
-	Amount        float64 `json:"Amount"`
-	Currency      string  `json:"Currency"`
-	Confirmations int     `json:"Confirmations"`
-	LastUpdated   jTime   `json:"LastUpdated"`
-	TxId          string  `json:"TxId"`
-	CryptoAddress string  `json:"CryptoAddress"`
+	Id            int64           `json:"Id"`
+	Amount        decimal.Decimal `json:"Amount"`
+	Currency      string          `json:"Currency"`
+	Confirmations int             `json:"Confirmations"`
+	LastUpdated   jTime           `json:"LastUpdated"`
+	TxId          string          `json:"TxId"`
+	CryptoAddress string          `json:"CryptoAddress"`
 }

--- a/market.go
+++ b/market.go
@@ -1,14 +1,16 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Market struct {
-	MarketCurrency     string  `json:"MarketCurrency"`
-	BaseCurrency       string  `json:"BaseCurrency"`
-	MarketCurrencyLong string  `json:"MarketCurrencyLong"`
-	BaseCurrencyLong   string  `json:"BaseCurrencyLong"`
-	MinTradeSize       float64 `json:"MinTradeSize"`
-	MarketName         string  `json:"MarketName"`
-	IsActive           bool    `json:"IsActive"`
-	Notice             string  `json:"Notice"`
-	IsSponsored        bool    `json:"IsSponsored"`
-	LogoUrl            string  `json:"LogoUrl"`
+	MarketCurrency     string          `json:"MarketCurrency"`
+	BaseCurrency       string          `json:"BaseCurrency"`
+	MarketCurrencyLong string          `json:"MarketCurrencyLong"`
+	BaseCurrencyLong   string          `json:"BaseCurrencyLong"`
+	MinTradeSize       decimal.Decimal `json:"MinTradeSize"`
+	MarketName         string          `json:"MarketName"`
+	IsActive           bool            `json:"IsActive"`
+	Notice             string          `json:"Notice"`
+	IsSponsored        bool            `json:"IsSponsored"`
+	LogoUrl            string          `json:"LogoUrl"`
 }

--- a/marketSummary.go
+++ b/marketSummary.go
@@ -1,16 +1,18 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type MarketSummary struct {
-	MarketName     string  `json:"MarketName"`
-	High           float64 `json:"High"`
-	Low            float64 `json:"Low"`
-	Ask            float64 `json:"Ask"`
-	Bid            float64 `json:"Bid"`
-	OpenBuyOrders  int     `json:"OpenBuyOrders"`
-	OpenSellOrders int     `json:"OpenSellOrders"`
-	Volume         float64 `json:"Volume"`
-	Last           float64 `json:"Last"`
-	BaseVolume     float64 `json:"BaseVolume"`
-	PrevDay        float64 `json:"PrevDay"`
-	TimeStamp      string  `json:"TimeStamp"`
+	MarketName     string          `json:"MarketName"`
+	High           decimal.Decimal `json:"High"`
+	Low            decimal.Decimal `json:"Low"`
+	Ask            decimal.Decimal `json:"Ask"`
+	Bid            decimal.Decimal `json:"Bid"`
+	OpenBuyOrders  int             `json:"OpenBuyOrders"`
+	OpenSellOrders int             `json:"OpenSellOrders"`
+	Volume         decimal.Decimal `json:"Volume"`
+	Last           decimal.Decimal `json:"Last"`
+	BaseVolume     decimal.Decimal `json:"BaseVolume"`
+	PrevDay        decimal.Decimal `json:"PrevDay"`
+	TimeStamp      string          `json:"TimeStamp"`
 }

--- a/order.go
+++ b/order.go
@@ -1,16 +1,18 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Order struct {
-	OrderUuid         string  `json:"OrderUuid"`
-	Exchange          string  `json:"Exchange"`
-	TimeStamp         jTime   `json:"TimeStamp"`
-	OrderType         string  `json:"OrderType"`
-	Limit             float64 `json:"Limit"`
-	Quantity          float64 `json:"Quantity"`
-	QuantityRemaining float64 `json:"QuantityRemaining"`
-	Commission        float64 `json:"Commission"`
-	Price             float64 `json:"Price"`
-	PricePerUnit      float64 `json:"PricePerUnit"`
+	OrderUuid         string          `json:"OrderUuid"`
+	Exchange          string          `json:"Exchange"`
+	TimeStamp         jTime           `json:"TimeStamp"`
+	OrderType         string          `json:"OrderType"`
+	Limit             decimal.Decimal `json:"Limit"`
+	Quantity          decimal.Decimal `json:"Quantity"`
+	QuantityRemaining decimal.Decimal `json:"QuantityRemaining"`
+	Commission        decimal.Decimal `json:"Commission"`
+	Price             decimal.Decimal `json:"Price"`
+	PricePerUnit      decimal.Decimal `json:"PricePerUnit"`
 }
 
 // For getorder
@@ -19,16 +21,16 @@ type Order2 struct {
 	OrderUuid                  string `json:"OrderUuid"`
 	Exchange                   string `json:"Exchange"`
 	Type                       string
-	Quantity                   float64 `json:"Quantity"`
-	QuantityRemaining          float64 `json:"QuantityRemaining"`
-	Limit                      float64 `json:"Limit"`
-	Reserved                   float64
-	ReserveRemaining           float64
-	CommissionReserved         float64
-	CommissionReserveRemaining float64
-	CommissionPaid             float64
-	Price                      float64 `json:"Price"`
-	PricePerUnit               float64 `json:"PricePerUnit"`
+	Quantity                   decimal.Decimal `json:"Quantity"`
+	QuantityRemaining          decimal.Decimal `json:"QuantityRemaining"`
+	Limit                      decimal.Decimal `json:"Limit"`
+	Reserved                   decimal.Decimal
+	ReserveRemaining           decimal.Decimal
+	CommissionReserved         decimal.Decimal
+	CommissionReserveRemaining decimal.Decimal
+	CommissionPaid             decimal.Decimal
+	Price                      decimal.Decimal `json:"Price"`
+	PricePerUnit               decimal.Decimal `json:"PricePerUnit"`
 	Opened                     string
 	Closed                     string
 	IsOpen                     bool

--- a/ticker.go
+++ b/ticker.go
@@ -1,7 +1,9 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Ticker struct {
-	Bid  float64 `json:"Bid"`
-	Ask  float64 `json:"Ask"`
-	Last float64 `json:"Last"`
+	Bid  decimal.Decimal `json:"Bid"`
+	Ask  decimal.Decimal `json:"Ask"`
+	Last decimal.Decimal `json:"Last"`
 }

--- a/trade.go
+++ b/trade.go
@@ -1,12 +1,14 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 // Used in getmarkethistory
 type Trade struct {
-	OrderUuid int64   `json:"Id"`
-	Timestamp jTime   `json:"TimeStamp"`
-	Quantity  float64 `json:"Quantity"`
-	Price     float64 `json:"Price"`
-	Total     float64 `json:"Total"`
-	FillType  string  `json:"FillType"`
-	OrderType string  `json:"OrderType"`
+	OrderUuid int64           `json:"Id"`
+	Timestamp jTime           `json:"TimeStamp"`
+	Quantity  decimal.Decimal `json:"Quantity"`
+	Price     decimal.Decimal `json:"Price"`
+	Total     decimal.Decimal `json:"Total"`
+	FillType  string          `json:"FillType"`
+	OrderType string          `json:"OrderType"`
 }

--- a/withdrawal.go
+++ b/withdrawal.go
@@ -1,14 +1,16 @@
 package bittrex
 
+import "github.com/shopspring/decimal"
+
 type Withdrawal struct {
-	PaymentUuid    string  `json:"PaymentUuid"`
-	Currency       string  `json:"Currency"`
-	Amount         float64 `json:"Amount"`
-	Address        string  `json:"Address"`
-	Opened         jTime   `json:"Opened"`
-	Authorized     bool    `json:"Authorized"`
-	PendingPayment bool    `json:"PendingPayment"`
-	TxCost         float64 `json:"TxCost"`
-	TxId           string  `json:"TxId"`
-	Canceled       bool    `json:"Canceled"`
+	PaymentUuid    string          `json:"PaymentUuid"`
+	Currency       string          `json:"Currency"`
+	Amount         decimal.Decimal `json:"Amount"`
+	Address        string          `json:"Address"`
+	Opened         jTime           `json:"Opened"`
+	Authorized     bool            `json:"Authorized"`
+	PendingPayment bool            `json:"PendingPayment"`
+	TxCost         decimal.Decimal `json:"TxCost"`
+	TxId           string          `json:"TxId"`
+	Canceled       bool            `json:"Canceled"`
 }


### PR DESCRIPTION
currently most values are not really reliable because they are casted to float64.

For example 0,01905563 + 0,01905697 will yield 0.038113 instead of 0.0381126, which is getting increasingly more important :)