### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,7 +36,7 @@ func NewClientWithCustomHttpConfig(apiKey, apiSecret string, httpClient *http.Cl
 	return &client{apiKey, apiSecret, httpClient, timeout, false}
 }
 
-// NewClient returns a new Bittrex HTTP client with custom timeout
+// NewClientWithCustomTimeout returns a new Bittrex HTTP client with custom timeout
 func NewClientWithCustomTimeout(apiKey, apiSecret string, timeout time.Duration) (c *client) {
 	return &client{apiKey, apiSecret, &http.Client{}, timeout, false}
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?