### PR TITLE
Fix to CreateOrder function

### DIFF
--- a/bittrex.go
+++ b/bittrex.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/go-querystring/query"
-	"github.com/shopspring/decimal"
 	"log"
 	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/shopspring/decimal"
 )
 
 const (
@@ -245,23 +246,21 @@ func (b *Bittrex) BuyLimit(market string, quantity, rate decimal.Decimal) (uuid 
 
 // CreateOrder is used to create any type of supported order.
 func (b *Bittrex) CreateOrder(params CreateOrderParams) (order OrderV3, err error) {
+
 	// TODO Preprocessor
 	if params.Type == "" || params.MarketSymbol == "" || params.Direction == "" || params.TimeInForce == "" {
 		// Check for missing parameters
 		return OrderV3{}, ERR_ORDER_MISSING_PARAMETERS
 	}
-	var finalParams = CreateOrderParams{
-		MarketSymbol:  params.MarketSymbol,
-		Direction:     params.Direction,
-		Type:          params.Type,
-		Quantity:      decimal.Decimal{},
-		Ceiling:       decimal.Decimal{},
-		Limit:         decimal.Decimal{},
-		TimeInForce:   params.TimeInForce,
-		ClientOrderID: params.ClientOrderID,
-		UseAwards:     params.UseAwards,
-	}
 
+	// Mandatory fields
+	var finalParams CreateOrderParams
+	finalParams.Type = params.Type
+	finalParams.MarketSymbol = params.MarketSymbol
+	finalParams.Direction = params.Direction
+	finalParams.TimeInForce = params.TimeInForce
+
+	// Per-type fields
 	switch params.Type {
 	case MARKET:
 		finalParams.Quantity = params.Quantity
@@ -272,7 +271,6 @@ func (b *Bittrex) CreateOrder(params CreateOrderParams) (order OrderV3, err erro
 		finalParams.Ceiling = params.Ceiling
 	case CEILING_MARKET:
 		finalParams.Ceiling = params.Ceiling
-
 	}
 
 	payload, err := json.Marshal(finalParams)
@@ -280,9 +278,11 @@ func (b *Bittrex) CreateOrder(params CreateOrderParams) (order OrderV3, err erro
 		return
 	}
 	r, err := b.client.do("POST", fmt.Sprintf("orders"), string(payload), true)
+
 	if err != nil {
 		return
 	}
+
 	err = json.Unmarshal(r, &order)
 	return
 }

--- a/client.go
+++ b/client.go
@@ -105,7 +105,6 @@ func (c *client) do(method string, resource string, payload string, authNeeded b
 	} else {
 		rawurl = fmt.Sprintf("%s%s/%s", API_BASE, API_VERSION, resource)
 	}
-	fmt.Println("url: ", rawurl)
 
 	req, err := http.NewRequest(method, rawurl, strings.NewReader(payload))
 	if err != nil {
@@ -128,7 +127,7 @@ func (c *client) do(method string, resource string, payload string, authNeeded b
 		payloadHash := hex.EncodeToString(payloadSum[:])
 
 		// Unix timestamp in milliseconds
-		nonce := time.Now().Unix()*1000
+		nonce := time.Now().Unix() * 1000
 
 		// All of the signature elemnts must be parsed as strings in this array.
 		preSignatura := []string{strconv.Itoa(int(nonce)), req.URL.String(), method, payloadHash}
@@ -152,12 +151,12 @@ func (c *client) do(method string, resource string, payload string, authNeeded b
 
 	defer resp.Body.Close()
 	response, err = ioutil.ReadAll(resp.Body)
-	//fmt.Println(fmt.Sprintf("reponse %s", response), err)
+
 	if err != nil {
 		return response, err
 	}
-	if resp.StatusCode != 200 && resp.StatusCode != 201{
-		err = errors.New(resp.Status)
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		err = errors.New(fmt.Sprintf("status: %v message:%s", resp.Status, string(response)))
 	}
 	return response, err
 }

--- a/order.go
+++ b/order.go
@@ -1,8 +1,9 @@
 package bittrex
 
 import (
-	"github.com/shopspring/decimal"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 type Order struct {
@@ -53,35 +54,36 @@ type Order2 struct {
 }
 
 type CreateOrderParams struct {
-	MarketSymbol  string `json:"marketSymbol"`
-	Direction     OrderDirection `json:"direction"`
-	Type          OrderType `json:"type"`
-	Quantity      decimal.Decimal `json:"quantity"`
-	Ceiling       decimal.Decimal `json:"ceiling"`
-	Limit         decimal.Decimal `json:"limit"`
-	TimeInForce   TimeInForce `json:"timeInForce"`
-	ClientOrderID string `json:"clientOrderId"`
-	UseAwards     string `json:"useAwards"`
+	MarketSymbol string          `json:"marketSymbol"`
+	Direction    OrderDirection  `json:"direction"`
+	Type         OrderType       `json:"type"`
+	Quantity     decimal.Decimal `json:"quantity"`
+	TimeInForce  TimeInForce     `json:"timeInForce"`
+
+	Ceiling       float64 `json:"ceiling,omitempty"`
+	Limit         float64 `json:"limit,omitempty"`
+	ClientOrderID string  `json:"clientOrderId,omitempty"`
+	UseAwards     string  `json:"useAwards,omitempty"`
 }
 
 type OrderV3 struct {
-	ID            string `json:"id"`
-	MarketSymbol  string `json:"marketSymbol"`
-	Direction     string `json:"direction"`
-	Type          string `json:"type"`
+	ID            string          `json:"id"`
+	MarketSymbol  string          `json:"marketSymbol"`
+	Direction     string          `json:"direction"`
+	Type          string          `json:"type"`
 	Quantity      decimal.Decimal `json:"quantity"`
 	Limit         decimal.Decimal `json:"limit"`
 	Ceiling       decimal.Decimal `json:"ceiling"`
-	TimeInForce   string `json:"timeInForce"`
-	ClientOrderID string `json:"clientOrderId"`
+	TimeInForce   string          `json:"timeInForce"`
+	ClientOrderID string          `json:"clientOrderId"`
 	FillQuantity  decimal.Decimal `json:"fillQuantity"`
 	Commission    decimal.Decimal `json:"commission"`
 	Proceeds      decimal.Decimal `json:"proceeds"`
-	Status        string `json:"status"`
-	CreatedAt     time.Time `json:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt"`
-	ClosedAt      time.Time `json:"closedAt"`
-	OrderToCancel OrderData `json:"orderToCancel"`
+	Status        string          `json:"status"`
+	CreatedAt     time.Time       `json:"createdAt"`
+	UpdatedAt     time.Time       `json:"updatedAt"`
+	ClosedAt      time.Time       `json:"closedAt"`
+	OrderToCancel OrderData       `json:"orderToCancel"`
 }
 
 type OrderData struct {


### PR DESCRIPTION
Fix to CreateOrder function, request was sent with optional fields that would cause an error on the API
Added support to client so that it returns API errors, instead of only getting the status code back
Removed pending `fmt.Println` in `client.go`